### PR TITLE
AVX-90 fix STM32F302xB registry

### DIFF
--- a/os/hal/ports/STM32/STM32F3xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32F3xx/stm32_registry.h
@@ -1307,7 +1307,7 @@
 #define STM32_HAS_ETH                       FALSE
 
 /* EXTI attributes.*/
-#define STM32_EXTI_NUM_LINES                34
+#define STM32_EXTI_NUM_LINES                33
 #define STM32_EXTI_IMR_MASK                 0x1F800000U
 #define STM32_EXTI_IMR2_MASK                0xFFFFFFFCU
 


### PR DESCRIPTION
Fix registry for STM32F302xB in ChibiOS.  This bug was originally found in the STM32F302xE.  It also applies here.